### PR TITLE
Summary:

### DIFF
--- a/dockerfiles/Dockerfile.sdl_build.u18.04
+++ b/dockerfiles/Dockerfile.sdl_build.u18.04
@@ -3,7 +3,7 @@ ARG DEBIAN_FRONTEND=noninteractive
 RUN apt update && apt install -yq \
     automake \
     ccache \
-    clang-format-6.0 \
+    clang-format-8 \
     g++ \
     gdb \
     lcov \


### PR DESCRIPTION
These changes introduce modifications made to Dockerfile where we are changing the clang-format from version 6.0 to 8.

It is based on the following [PR#337](https://github.com/smartdevicelink/sdl_core/pull/3727)

