### PR TITLE
Updating Dockerfiles with clang-format version 8.

### DIFF
--- a/dockerfiles/Dockerfile.sdl_build.u18.04
+++ b/dockerfiles/Dockerfile.sdl_build.u18.04
@@ -3,7 +3,7 @@ ARG DEBIAN_FRONTEND=noninteractive
 RUN apt update && apt install -yq \
     automake \
     ccache \
-    clang-format-6.0 \
+    clang-format-8 \
     g++ \
     gdb \
     lcov \

--- a/dockerfiles/Dockerfile.sdl_build.u18.04
+++ b/dockerfiles/Dockerfile.sdl_build.u18.04
@@ -3,6 +3,7 @@ ARG DEBIAN_FRONTEND=noninteractive
 RUN apt update && apt install -yq \
     automake \
     ccache \
+    clang-format-6.0 \
     clang-format-8 \
     g++ \
     gdb \


### PR DESCRIPTION
We are updating the clang-format from version 6.0 to version 8.
The base for this change is the following [PR#3727](https://github.com/smartdevicelink/sdl_core/pull/3727)

